### PR TITLE
Fix/video upload

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -46,9 +46,12 @@ class OrganizationsController < ApplicationController
       videos.each do |video|
         vimeo_video = VimeoMe2::Video.new(ENV['VIMEO_API_TOKEN'], video.data_url)
         vimeo_video.destroy
-        video.delete
       end
     end
+    @organization.destroy!
+    flash[:danger] = "#{@organization.name}を削除しました"
+    redirect_to organizations_url
+  rescue VimeoMe2::RequestFailed
     @organization.destroy!
     flash[:danger] = "#{@organization.name}を削除しました"
     redirect_to organizations_url

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   enum role: { owner: 0, staff: 1 }
 
   belongs_to :organization
-  has_many :videos
+  has_many :videos, dependent: :nullify
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }

--- a/db/migrate/20220814152201_create_videos.rb
+++ b/db/migrate/20220814152201_create_videos.rb
@@ -13,7 +13,7 @@ class CreateVideos < ActiveRecord::Migration[6.1]
       t.boolean :is_valid, default:true, null:false
 
       t.references :organization, null: false, foreign_key: true
-      t.references :user, null: false, foreign_key: true
+      t.references :user, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -144,7 +144,7 @@ ActiveRecord::Schema.define(version: 2022_09_07_213435) do
     t.string "data_url", null: false
     t.boolean "is_valid", default: true, null: false
     t.bigint "organization_id", null: false
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["organization_id"], name: "index_videos_on_organization_id"

--- a/spec/requests/organizations/organization_spec.rb
+++ b/spec/requests/organizations/organization_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Organization', type: :request do
   let(:user_staff) { create(:user_staff, confirmed_at: Time.now) }
   let(:viewer) { create(:viewer, confirmed_at: Time.now) }
   let(:viewer1) { create(:viewer1, confirmed_at: Time.now) }
+  let(:video_sample) { create(:video_sample, organization_id: user_owner.organization.id, user_id: user_owner.id) }
 
   let(:another_organization) { create(:another_organization) }
   let(:another_user_owner) { create(:another_user_owner, confirmed_at: Time.now) }
@@ -26,6 +27,7 @@ RSpec.describe 'Organization', type: :request do
     user_staff
     viewer
     viewer1
+    video_sample
     another_organization
     another_user_owner
     another_user_staff
@@ -822,7 +824,7 @@ RSpec.describe 'Organization', type: :request do
         it '組織を削除する' do
           expect {
             delete organization_path(organization), params: { id: organization.id }
-          }.to change(Organization, :count).by(-1)
+          }.to change(Organization, :count).by(-1) && change(Video, :count).by(-1)
         end
 
         it 'indexにリダイレクトされる' do

--- a/spec/system/organizations/organization_spec.rb
+++ b/spec/system/organizations/organization_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'OrganizationSystem', type: :system do
   let(:user_owner) { create(:user_owner, confirmed_at: Time.now) }
   let(:user_staff) { create(:user_staff, confirmed_at: Time.now) }
   let(:user_staff1) { create(:user_staff1, confirmed_at: Time.now) }
+  let(:video_sample) { create(:video_sample, organization_id: user_owner.organization.id, user_id: user_owner.id) }
 
   let(:another_organization) { create(:another_organization) }
   let(:another_user_owner) { create(:another_user_owner, confirmed_at: Time.now) }
@@ -18,6 +19,7 @@ RSpec.describe 'OrganizationSystem', type: :system do
     user_owner
     user_staff
     user_staff1
+    video_sample
     another_organization
     another_user_owner
     another_user_staff
@@ -218,7 +220,7 @@ RSpec.describe 'OrganizationSystem', type: :system do
             expect(page.driver.browser.switch_to.alert.text).to eq 'セレブエンジニアの組織情報を削除します。本当によろしいですか？'
             page.driver.browser.switch_to.alert.accept
             expect(page).to have_content 'セレブエンジニアを削除しました'
-          }.to change(Organization, :count).by(-1)
+          }.to change(Organization, :count).by(-1) && change(Video, :count).by(-1)
         end
 
         it 'another_organization削除キャンセル' do


### PR DESCRIPTION
### 概要
_動画アップロード機能と視聴_

### タスク
- [ ] なし
- [x] あり _(https://trello.com/c/yac7tkkl/45-%E5%8B%95%E7%94%BB%E3%82%A2%E3%83%83%E3%83%97%E3%83%AD%E3%83%BC%E3%83%89%E6%A9%9F%E8%83%BD%E3%81%AE%E5%AE%9F%E8%A3%85)_

###  修正内容・手法
●user削除時に発生するエラーを解消(videoモデルのuser_idのnilを許可)

●organization削除時に発生するエラーを解消(組織の動画がvimeo内からすでに削除されている場合への対応)

・M1 macによる影響
system/organizations/organization_spec.rb:217行目のテストについて
→xdescribe→describeと変更することで、pending状態を解除し、テストお願いいたします。

### 実装画像などあれば添付する

### テスト(実施項目は下記)
https://docs.google.com/spreadsheets/d/111oIPYOqD0cG8tjb3XF5JdPKzYENSJFlhQFN1-3AD_Q/edit#gid=743144401
14行目改　()内の追記