### PR TITLE
非アクティブと同じメールアドレスを使用可能へと修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-    :recoverable, :rememberable, :validatable,
+    :recoverable, :rememberable,
     :confirmable
 
   # 初期値 owner
@@ -14,12 +14,19 @@ class User < ApplicationRecord
   has_many :videos, dependent: :nullify
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-  validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
-  validates :name,  presence: true, length: { in: 1..10 }
+  validates :email, presence: true, uniqueness: { if: :user_exists? }, format: { with: VALID_EMAIL_REGEX }
+  validates :name, presence: true, length: { in: 1..10 }
+  validates :password, presence: true, length: { in: 6..128 }, confirmation: true, on: :create
 
   # 引数のorganization_idと一致するuserの絞り込み
   scope :current_owner_has, ->(current_user) { where(organization_id: current_user.organization_id) }
   scope :user_has, ->(organization_id) { includes([:organization]).where(organization_id: organization_id) }
   # 退会者は省く絞り込み
   scope :subscribed, -> { where(is_valid: true) }
+
+  # アクティブuserと同じemailが存在すればtrueを返す（trueでuniqueness検知する）
+  def user_exists?
+    user = User.subscribed.where(email: self.email).where.not(id: self.id)
+    user.present?
+  end
 end

--- a/app/models/viewer.rb
+++ b/app/models/viewer.rb
@@ -7,12 +7,13 @@ class Viewer < ApplicationRecord
   # Include default devise modules. Others available are:
   # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-    :recoverable, :rememberable, :validatable,
+    :recoverable, :rememberable,
     :confirmable
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-  validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
+  validates :email, presence: true, uniqueness: { if: :viewer_exists? }, format: { with: VALID_EMAIL_REGEX }
   validates :name,  presence: true, length: { in: 1..10 }
+  validates :password, presence: true, length: { in: 6..128 }, confirmation: true, on: :create
 
   # 引数のorganization_idと一致するviewerの絞り込み
   scope :current_owner_has, lambda { |current_user|
@@ -23,4 +24,10 @@ class Viewer < ApplicationRecord
                      }
   # 退会者は省く絞り込み
   scope :subscribed, -> { where(is_valid: true) }
+
+  # アクティブviewerと同じemailが存在すればtrueを返す（trueでuniqueness検知する）
+  def viewer_exists?
+    viewer = Viewer.subscribed.where(email: self.email).where.not(id: self.id)
+    return viewer.present?
+  end
 end

--- a/db/migrate/20210508010419_devise_create_viewers.rb
+++ b/db/migrate/20210508010419_devise_create_viewers.rb
@@ -42,7 +42,6 @@ class DeviseCreateViewers < ActiveRecord::Migration[6.1]
       t.timestamps null: false
     end
 
-    add_index :viewers, :email,                unique: true
     add_index :viewers, :reset_password_token, unique: true
     add_index :viewers, :confirmation_token,   unique: true
     add_index :viewers, :unlock_token,         unique: true

--- a/db/migrate/20210508010836_devise_create_users.rb
+++ b/db/migrate/20210508010836_devise_create_users.rb
@@ -42,7 +42,6 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.1]
       t.timestamps null: false
     end
 
-    add_index :users, :email,                unique: true
     add_index :users, :reset_password_token, unique: true
     add_index :users, :confirmation_token,   unique: true
     add_index :users, :unlock_token,         unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -127,7 +127,6 @@ ActiveRecord::Schema.define(version: 2022_09_07_213435) do
     t.integer "organization_id", default: 1, null: false
     t.boolean "is_valid", default: true, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
-    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
@@ -179,12 +178,10 @@ ActiveRecord::Schema.define(version: 2022_09_07_213435) do
     t.string "name"
     t.boolean "is_valid", default: true, null: false
     t.index ["confirmation_token"], name: "index_viewers_on_confirmation_token", unique: true
-    t.index ["email"], name: "index_viewers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_viewers_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_viewers_on_unlock_token", unique: true
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "organization_viewers", "organizations"
   add_foreign_key "organization_viewers", "viewers"

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -10,4 +10,11 @@ FactoryBot.define do
     name           { 'テックリーダーズ' }
     email          { 'org_spec1@example.com' }
   end
+
+  factory :deactivated_organization, class: 'Organization' do
+    id             { 3 }
+    name           { '非アクティブ組織' }
+    email          { 'org_spec2@example.com' }
+    is_valid       { false }
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -45,4 +45,14 @@ FactoryBot.define do
     organization_id  { 2 }
     role             { 'staff' }
   end
+  
+  factory :deactivated_user, class: 'User' do
+    id               { 6 }
+    name             { '非アクティブ投稿者' }
+    email            { 'staff_spec3@example.com' }
+    password         { 'password' }
+    organization_id  { 1 }
+    role             { 'staff' }
+    is_valid         { false }
+  end
 end

--- a/spec/factories/viewers.rb
+++ b/spec/factories/viewers.rb
@@ -21,4 +21,12 @@ FactoryBot.define do
     email    { 'viewer_spec2@example.com' }
     password { 'password' }
   end
+
+  factory :deactivated_viewer, class: 'Viewer' do
+    id       { 4 }
+    name     { '非アクティブ視聴者' }
+    email    { 'viewer_spec3@example.com' }
+    password { 'password' }
+    is_valid { false }
+  end
 end

--- a/spec/models/organizations/organization_spec.rb
+++ b/spec/models/organizations/organization_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Organization, type: :model do
-  let :organization do
-    build(:organization)
-  end
+  let(:organization) { build(:organization) }
+  let(:deactivated_organization) { create(:deactivated_organization) }
 
   describe 'バリデーションについて' do
     subject do
@@ -34,6 +33,8 @@ RSpec.describe Organization, type: :model do
         before :each do
           organization = create(:organization)
           subject.email = organization.email
+          # 同じidだとバリデーションが反応しない為ずらす
+          subject.id = organization.id + 1
         end
 
         it 'バリデーションに落ちること' do
@@ -65,6 +66,16 @@ RSpec.describe Organization, type: :model do
             subject.valid?
             expect(subject.errors.full_messages).to include('組織のEメールは不正な値です')
           end
+        end
+      end
+
+      context '非アクティブアカウントと同じemailを使用した場合' do
+        before :each do
+          subject.email = deactivated_organization.email
+        end
+
+        it 'バリデーションが通ること' do
+          expect(subject).to be_valid
         end
       end
     end

--- a/spec/requests/users/user_spec.rb
+++ b/spec/requests/users/user_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'User', type: :request do
   let(:user_owner) { create(:user_owner, confirmed_at: Time.now) }
   let(:user_staff) { create(:user_staff, confirmed_at: Time.now) }
   let(:user_staff1) { create(:user_staff1, confirmed_at: Time.now) }
+  let(:deactivated_user) { create(:deactivated_user, confirmed_at: Time.now) }
   let(:viewer) { create(:viewer, confirmed_at: Time.now) }
   let(:viewer1) { create(:viewer1, confirmed_at: Time.now) }
 
@@ -25,6 +26,7 @@ RSpec.describe 'User', type: :request do
     organization
     user_owner
     user_staff
+    deactivated_user
     viewer
     viewer1
     another_organization
@@ -266,6 +268,20 @@ RSpec.describe 'User', type: :request do
             }
           )
         ).to redirect_to users_url
+      end
+
+      it '非アクティブアカウントと同じメールアドレスは仕様可能' do
+        expect {
+          post users_path,
+            params: {
+              user: {
+                name:                  'staff',
+                email:                 deactivated_user.email,
+                password:              'password',
+                password_confirmation: 'password'
+              }
+            }
+        }.to change(User, :count).by(1)
       end
     end
 

--- a/spec/requests/viewers/registration_spec.rb
+++ b/spec/requests/viewers/registration_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe 'ViewerRegistration', type: :request do
+  let(:deactivated_viewer) { create(:deactivated_viewer, confirmed_at: Time.now) }
+
+  before(:each) do
+    deactivated_viewer
+  end
+
   describe '視聴者新規作成' do
     describe '正常' do
       it '新規作成' do
@@ -31,6 +37,21 @@ RSpec.describe 'ViewerRegistration', type: :request do
             }
           )
         ).to redirect_to new_viewer_session_url
+      end
+
+      it '非アクティブアカウントと同じメールアドレスは仕様可能' do
+        get new_viewer_registration_path
+        expect {
+          post viewer_registration_path,
+            params: {
+              viewer: {
+                name:                  'test',
+                email:                 deactivated_viewer.email,
+                password:              'password',
+                password_confirmation: 'password'
+              }
+            }
+        }.to change(Viewer, :count).by(1)
       end
     end
 

--- a/spec/system/organizations/folder_spec.rb
+++ b/spec/system/organizations/folder_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.xdescribe 'UsersSystem', type: :system, js: true do
+RSpec.describe 'UsersSystem', type: :system, js: true do
   let(:organization) { create(:organization) }
   let(:another_organization) { create(:another_organization) }
   let(:system_admin) { create(:system_admin) }

--- a/spec/system/users/user_spec.rb
+++ b/spec/system/users/user_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'UserSystem', type: :system do
   let(:user_owner) { create(:user_owner, confirmed_at: Time.now) }
   let(:user_staff) { create(:user_staff, confirmed_at: Time.now) }
   let(:user_staff1) { create(:user_staff1, confirmed_at: Time.now) }
+  let(:deactivated_user) { create(:deactivated_user, confirmed_at: Time.now) }
 
   let(:another_organization) { create(:another_organization) }
   let(:another_user_owner) { create(:another_user_owner, confirmed_at: Time.now) }
@@ -18,6 +19,7 @@ RSpec.describe 'UserSystem', type: :system do
     user_owner
     user_staff
     user_staff1
+    deactivated_user
     another_organization
     another_user_owner
     another_user_staff
@@ -338,6 +340,14 @@ RSpec.describe 'UserSystem', type: :system do
           expect(page).to have_current_path users_path, ignore_query: true
           expect(page).to have_text '更新しました'
         end
+
+        it '非アクティブアカウントと同じメールアドレスは更新可能' do
+          fill_in 'Name', with: 'test'
+          fill_in 'Eメール', with: deactivated_user.email
+          click_button '更新'
+          expect(page).to have_current_path users_path, ignore_query: true
+          expect(page).to have_text '更新しました'
+        end
       end
 
       context 'スタッフ新規作成' do
@@ -357,6 +367,16 @@ RSpec.describe 'UserSystem', type: :system do
         it '登録でスタッフが新規作成される' do
           fill_in 'Name', with: 'test'
           fill_in 'Eメール', with: 'sample@email.com'
+          fill_in 'パスワード', with: 'password'
+          fill_in 'パスワード（確認用）', with: 'password'
+          click_button '登録'
+          expect(page).to have_current_path users_path, ignore_query: true
+          expect(page).to have_text 'testの作成に成功しました'
+        end
+
+        it '非アクティブアカウントと同じメールアドレスは新規作成可能' do
+          fill_in 'Name', with: 'test'
+          fill_in 'Eメール', with: deactivated_user.email
           fill_in 'パスワード', with: 'password'
           fill_in 'パスワード（確認用）', with: 'password'
           click_button '登録'

--- a/spec/system/videos/hidden_spec.rb
+++ b/spec/system/videos/hidden_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.xdescribe 'VideoUnsubscribeSystem', type: :system, js: true do
+RSpec.describe 'VideoUnsubscribeSystem', type: :system, js: true do
   let(:system_admin) { create(:system_admin, confirmed_at: Time.now) }
   let(:organization) { create(:organization) }
   let(:user_owner) { create(:user_owner, organization_id: organization.id, confirmed_at: Time.now) }

--- a/spec/system/videos/videos_spec.rb
+++ b/spec/system/videos/videos_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.xdescribe 'VideosSystem', type: :system, js: true do
+RSpec.describe 'VideosSystem', type: :system, js: true do
   let(:system_admin) { create(:system_admin, confirmed_at: Time.now) }
 
   let(:organization) { create(:organization) }

--- a/spec/system/viewers/registration_spec.rb
+++ b/spec/system/viewers/registration_spec.rb
@@ -1,12 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe 'ViewerRegistrationSystem', type: :system do
+  let(:deactivated_viewer) { create(:deactivated_viewer, confirmed_at: Time.now) }
+
+  before(:each) do
+    deactivated_viewer
+  end
+
   describe '正常' do
     it '視聴者新規作成' do
       visit new_viewer_registration_path
       expect {
         fill_in 'viewer[name]', with: 'test'
         fill_in 'viewer[email]', with: 'test@email.com'
+        fill_in 'viewer[password]', with: 'password'
+        fill_in 'viewer[password_confirmation]', with: 'password'
+        check 'agreeTerms'
+        click_button 'アカウント登録'
+      }.to change(Viewer, :count).by(1)
+    end
+
+    it '非アクティブアカウントと同じメールアドレスは新規作成可能' do
+      visit new_viewer_registration_path
+      expect {
+        fill_in 'viewer[name]', with: 'test'
+        fill_in 'viewer[email]', with: deactivated_viewer.email
         fill_in 'viewer[password]', with: 'password'
         fill_in 'viewer[password_confirmation]', with: 'password'
         check 'agreeTerms'

--- a/spec/system/viewers/viewer_spec.rb
+++ b/spec/system/viewers/viewer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.xdescribe 'ViewerSystem', type: :system, js: true do
+RSpec.describe 'ViewerSystem', type: :system, js: true do
   let(:system_admin) { create(:system_admin, confirmed_at: Time.now) }
 
   let(:organization) { create(:organization) }
@@ -8,6 +8,8 @@ RSpec.xdescribe 'ViewerSystem', type: :system, js: true do
   let(:user_staff) { create(:user_staff, confirmed_at: Time.now) }
   let(:viewer) { create(:viewer, confirmed_at: Time.now) }
   let(:viewer1) { create(:viewer1, confirmed_at: Time.now) }
+  let(:deactivated_viewer) { create(:deactivated_viewer, confirmed_at: Time.now) }
+
 
   let(:organization_viewer) { create(:organization_viewer) }
   let(:organization_viewer2) { create(:organization_viewer2) }
@@ -20,6 +22,7 @@ RSpec.xdescribe 'ViewerSystem', type: :system, js: true do
     user_staff
     viewer
     viewer1
+    deactivated_viewer
     organization_viewer
     organization_viewer2
   end
@@ -302,6 +305,14 @@ RSpec.xdescribe 'ViewerSystem', type: :system, js: true do
         it '更新で登録情報が更新される' do
           fill_in 'Name', with: 'test'
           fill_in 'Eメール', with: 'sample@email.com'
+          click_button '更新'
+          expect(page).to have_current_path viewer_path(viewer), ignore_query: true
+          expect(page).to have_text '更新しました'
+        end
+
+        it '非アクティブアカウントと同じメールアドレスは更新可能' do
+          fill_in 'Name', with: 'test'
+          fill_in 'Eメール', with: deactivated_viewer.email
           click_button '更新'
           expect(page).to have_current_path viewer_path(viewer), ignore_query: true
           expect(page).to have_text '更新しました'


### PR DESCRIPTION
### 概要
アカウント関連の実装
非アクティブ（論理削除状態）のemailを再利用できるよう修正

### タスク
- [ ] あり[issues#13](https://github.com/koki-kato/video_share_app/issues/13)

### 実装内容・手法
・organization
・user
・viewer
以上のモデルを修正

emailのバリデーションを条件付け修正
deviseのパスワードバリデーションを削除
passwordのバリデーションの追加
Rspecの追記

### テスト項目書
https://docs.google.com/spreadsheets/d/1CumL67VUpUlBppV8dNzb7c4pDV-DQWl5BeafBfzY1K8/edit#gid=743144401

### 実装画像
https://docs.google.com/spreadsheets/d/1KYs7jYzZiXTYHl1Yhu-ZTrrC5BbROuGh0aJK8YKTjDo/edit?usp=sharing

### 本番環境(fly.io)
https://video-share-app6.fly.dev/
